### PR TITLE
Adjust badge colors for dance and review categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,8 @@
           // 可依名稱配色；未匹配則給中性樣式
           if (name === '課本') return 'badge-primary';
           if (name === '故事') return 'badge-secondary';
+          if (name === '跳舞歌曲') return 'bg-pink-500 text-white border-transparent shadow-sm';
+          if (name === '英文測驗複習') return 'bg-amber-500 text-white border-transparent shadow-sm';
           return 'badge-neutral';
         },
         refreshPage(){


### PR DESCRIPTION
## Summary
- give the dance songs badge a vivid pink highlight
- switch the English review quiz badge to a warm amber tone for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54d4bbcdc8326b10b621716346163